### PR TITLE
Combine overlapping ranges

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+==================
+
+  * Combine overlapping ranges
+
 1.1.0 / 2016-05-13
 ==================
 

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ function rangeParser (size, str) {
   ranges.type = str.slice(0, index)
 
   // parse all ranges
+  var lastBytePos = size - 1
   for (var i = 0; i < arr.length; i++) {
     var range = arr[i].split('-')
     var start = parseInt(range[0], 10)
@@ -45,15 +46,15 @@ function rangeParser (size, str) {
     // -nnn
     if (isNaN(start)) {
       start = size - end
-      end = size - 1
+      end = lastBytePos
     // nnn-
     } else if (isNaN(end)) {
-      end = size - 1
+      end = lastBytePos
     }
 
     // limit last-byte-pos to current length
-    if (end > size - 1) {
-      end = size - 1
+    if (end > lastBytePos) {
+      end = lastBytePos
     }
 
     // invalid or unsatisifiable
@@ -68,5 +69,30 @@ function rangeParser (size, str) {
     })
   }
 
-  return ranges.length ? ranges : -1
+  return ranges.length ? combineRanges(ranges) : -1
+}
+
+function combineRanges (ranges) {
+  if (ranges.length <= 1) {
+    return ranges
+  }
+  var type = ranges.type
+  ranges = ranges.sort(byStart)
+  var current = ranges[0]
+  var combined = [current]
+  for (var i = 1; i < ranges.length; i++) {
+    var next = ranges[i]
+    if (next.start - current.end > 1) {
+      combined.push(next)
+      current = next
+    } else if (next.end > current.end) {
+      current.end = next.end
+    }
+  }
+  combined.type = type
+  return combined
+}
+
+function byStart (a, b) {
+  return a.start - b.start
 }

--- a/test/range-parser.js
+++ b/test/range-parser.js
@@ -77,6 +77,14 @@ describe('parseRange(len, str)', function () {
     assert.deepEqual(range[1], { start: 999, end: 999 })
   })
 
+  it('should combine overlapping ranges', function () {
+    var range = parse(150, 'bytes=0-4,90-99,5-75,100-199,101-102')
+    assert.strictEqual(range.type, 'bytes')
+    assert.strictEqual(range.length, 2)
+    assert.deepEqual(range[0], { start: 0, end: 75 })
+    assert.deepEqual(range[1], { start: 90, end: 149 })
+  })
+
   it('should parse str with some invalid ranges', function () {
     var range = parse(200, 'bytes=0-499,1000-,500-999')
     assert.strictEqual(range.type, 'bytes')


### PR DESCRIPTION
As discussed in https://github.com/jshttp/range-parser/pull/14, this will combine overlapping ranges. Example:

```js
rangeParser(150, 'bytes=0-4,90-99,5-75,100-199,101-102')
> [{ "start": 0, "end": 75 }, { "start": 90, "end": 149 }]
```