### PR TITLE
Export `combineRanges()` function

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@
 
 module.exports = rangeParser
 
+rangeParser.combineRanges = combineRanges
+rangeParser.rangeParser   = rangeParser
+
 /**
  * Parse "Range" header `str` relative to the given file `size`.
  *


### PR DESCRIPTION
Export the `combineRanges()` function so it can be used directly.