### PR TITLE
Add max size on open range

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,21 @@ parseRange(100, 'bytes=50-55,0-10,5-10,56-60', { combine: true })
 //    ]
 ```
 
+##### limit
+
+Specifies total size for open ranges like `bytes=50-`, defaults not applyed.
+When used, end range part will be limited with selected value, this behavior allowed at RFC.
+Limit may be used to reduce load by greedy client.
+
+<!-- eslint-disable no-undef -->
+
+```js
+parseRange(1000, 'bytes=20-', { limit: 300 })
+// => [
+//      { start: 20,  end: 320 }
+//    ]
+```
+
 ## License
 
 [MIT](LICENSE)

--- a/index.js
+++ b/index.js
@@ -54,7 +54,12 @@ function rangeParser (size, str, options) {
       end = size - 1
     // nnn-
     } else if (isNaN(end)) {
-      end = size - 1
+      // used limit options for open ranges
+      if (options && options.limit) {
+        end = start + options.limit
+      } else {
+        end = size - 1
+      }
     }
 
     // limit last-byte-pos to current length

--- a/test/range-parser.js
+++ b/test/range-parser.js
@@ -115,4 +115,52 @@ describe('parseRange(len, str)', function () {
       assert.deepEqual(range[2], { start: 0, end: 1 })
     })
   })
+
+  describe('when limit: used', function () {
+    it('should limit end on "bytes=0-"', function () {
+      var range = parse(1000, 'bytes=0-', { limit: 300 })
+      assert.strictEqual(range.type, 'bytes')
+      assert.strictEqual(range.length, 1)
+      assert.deepEqual(range[0], { start: 0, end: 300 })
+    })
+
+    it('should not apply on fully defined range "bytes=0-200"', function () {
+      var range = parse(1000, 'bytes=0-200', { limit: 500 })
+      assert.strictEqual(range.type, 'bytes')
+      assert.strictEqual(range.length, 1)
+      assert.deepEqual(range[0], { start: 0, end: 200 })
+    })
+
+    it('should not apply on last bytes request "bytes=-200"', function () {
+      var range = parse(1000, 'bytes=-200', { limit: 500 })
+      assert.strictEqual(range.type, 'bytes')
+      assert.strictEqual(range.length, 1)
+      assert.deepEqual(range[0], { start: 800, end: 999 })
+    })
+
+    it('should consider end at size', function () {
+      var range = parse(1000, 'bytes=800-', { limit: 500 })
+      assert.strictEqual(range.type, 'bytes')
+      assert.strictEqual(range.length, 1)
+      assert.deepEqual(range[0], { start: 800, end: 999 })
+    })
+
+    it('should support multi ranges without combine:', function () {
+      var range = parse(1000, 'bytes=0-,20-120,100-,-200', { limit: 100 })
+      assert.strictEqual(range.type, 'bytes')
+      assert.strictEqual(range.length, 4)
+      assert.deepEqual(range[0], { start: 0, end: 100 })
+      assert.deepEqual(range[1], { start: 20, end: 120 })
+      assert.deepEqual(range[2], { start: 100, end: 200 })
+      assert.deepEqual(range[3], { start: 800, end: 999 })
+    })
+
+    it('should support multi ranges with combine:', function () {
+      var range = parse(1000, 'bytes=0-,20-120,100-,-200', { combine: true, limit: 100 })
+      assert.strictEqual(range.type, 'bytes')
+      assert.strictEqual(range.length, 2)
+      assert.deepEqual(range[0], { start: 0, end: 200 })
+      assert.deepEqual(range[1], { start: 800, end: 999 })
+    })
+  })
 })


### PR DESCRIPTION
As RFC described, open ranges like `50-` may be reduced by response server.
Add `limit` options.
Tests & docs at box.