### PR TITLE
fix: still show ranges if there are multiple ranges, even if some are invalid

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function rangeParser (size, str, options) {
 
   // check if there are multiple ranges
   var isMultiple = arr.length > 1
-  var hasValidFormat = false
+  var status = -2 // -2: all ranges invalid, -1: at least one valid but unsatisfiable
 
   // parse all ranges
   for (var i = 0; i < arr.length; i++) {
@@ -71,18 +71,16 @@ function rangeParser (size, str, options) {
       end = size - 1
     }
 
-    var isInvalidFormat = isNaN(start) || isNaN(end)
-
     // invalid format range
-    if (isInvalidFormat) {
+    if (isNaN(start) || isNaN(end)) {
       if (!isMultiple) {
         return -2
       }
       continue
     }
 
-    // track valid format
-    hasValidFormat = true
+    // unsatisifiable
+    status = -1
 
     // skip unsatisfiable ranges
     if (start > end || start < 0) {
@@ -97,12 +95,7 @@ function rangeParser (size, str, options) {
   }
 
   if (ranges.length < 1) {
-    // all ranges have invalid format
-    if (!hasValidFormat) {
-      return -2
-    }
-    // unsatisifiable
-    return -1
+    return status
   }
 
   return options && options.combine

--- a/index.js
+++ b/index.js
@@ -38,23 +38,17 @@ function rangeParser (size, str, options) {
   // split the range string
   var arr = str.slice(index + 1).split(',')
   var ranges = []
+  var code = -1
 
   // add ranges type
   ranges.type = str.slice(0, index)
-
-  // check if there are multiple ranges
-  var isMultiple = arr.length > 1
-  var status = -2 // -2: all ranges invalid, -1: at least one valid but unsatisfiable
 
   // parse all ranges
   for (var i = 0; i < arr.length; i++) {
     var indexOf = arr[i].indexOf('-')
     if (indexOf === -1) {
-      // ignore empty/whitespace-only ranges if there are other valid ranges
-      if (arr.length > 1 && arr[i].trim() === '') {
-        continue
-      }
-      return -2
+      code = -2
+      continue
     }
 
     var startStr = arr[i].slice(0, indexOf).trim()
@@ -77,14 +71,9 @@ function rangeParser (size, str, options) {
 
     // invalid format range
     if (isNaN(start) || isNaN(end)) {
-      if (!isMultiple) {
-        return -2
-      }
+      code = -2
       continue
     }
-
-    // unsatisifiable
-    status = -1
 
     // skip unsatisfiable ranges
     if (start > end || start < 0) {
@@ -99,7 +88,7 @@ function rangeParser (size, str, options) {
   }
 
   if (ranges.length < 1) {
-    return status
+    return code
   }
 
   return options && options.combine

--- a/index.js
+++ b/index.js
@@ -42,6 +42,10 @@ function rangeParser (size, str, options) {
   // add ranges type
   ranges.type = str.slice(0, index)
 
+  // check if there are multiple ranges
+  var isMultiple = arr.length > 1
+  var hasValidFormat = false
+
   // parse all ranges
   for (var i = 0; i < arr.length; i++) {
     var indexOf = arr[i].indexOf('-')
@@ -67,11 +71,20 @@ function rangeParser (size, str, options) {
       end = size - 1
     }
 
-    if (isNaN(start) || isNaN(end)) {
-      return -2
+    var isInvalidFormat = isNaN(start) || isNaN(end)
+
+    // invalid format range
+    if (isInvalidFormat) {
+      if (!isMultiple) {
+        return -2
+      }
+      continue
     }
 
-    // invalid or unsatisifiable
+    // track valid format
+    hasValidFormat = true
+
+    // skip unsatisfiable ranges
     if (start > end || start < 0) {
       continue
     }
@@ -84,6 +97,10 @@ function rangeParser (size, str, options) {
   }
 
   if (ranges.length < 1) {
+    // all ranges have invalid format
+    if (!hasValidFormat) {
+      return -2
+    }
     // unsatisifiable
     return -1
   }

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function rangeParser (size, str, options) {
   // split the range string
   var arr = str.slice(index + 1).split(',')
   var ranges = []
-  var code = -1
+  var valid = false
 
   // add ranges type
   ranges.type = str.slice(0, index)
@@ -47,7 +47,6 @@ function rangeParser (size, str, options) {
   for (var i = 0; i < arr.length; i++) {
     var indexOf = arr[i].indexOf('-')
     if (indexOf === -1) {
-      code = -2
       continue
     }
 
@@ -71,12 +70,12 @@ function rangeParser (size, str, options) {
 
     // invalid format range
     if (isNaN(start) || isNaN(end)) {
-      code = -2
       continue
     }
 
     // skip unsatisfiable ranges
     if (start > end || start < 0) {
+      valid = true
       continue
     }
 
@@ -88,7 +87,7 @@ function rangeParser (size, str, options) {
   }
 
   if (ranges.length < 1) {
-    return code
+    return valid ? -1 : -2
   }
 
   return options && options.combine

--- a/index.js
+++ b/index.js
@@ -50,6 +50,10 @@ function rangeParser (size, str, options) {
   for (var i = 0; i < arr.length; i++) {
     var indexOf = arr[i].indexOf('-')
     if (indexOf === -1) {
+      // ignore empty/whitespace-only ranges if there are other valid ranges
+      if (arr.length > 1 && arr[i].trim() === '') {
+        continue
+      }
       return -2
     }
 

--- a/test/range-parser.js
+++ b/test/range-parser.js
@@ -1,4 +1,3 @@
-
 var assert = require('assert')
 var deepEqual = require('deep-equal')
 var parse = require('..')
@@ -7,6 +6,12 @@ describe('parseRange(len, str)', function () {
   it('should reject non-string str', function () {
     assert.throws(parse.bind(null, 200, {}),
       /TypeError: argument str must be a string/)
+  })
+
+  it('should return -2 for range missing dash', function () {
+    assert.strictEqual(parse(200, 'bytes=100200'), -2)
+    assert.strictEqual(parse(200, 'bytes=,100200'), -2)
+    assert.strictEqual(parse(200, 'bytes=100-200,100200'), -2)
   })
 
   it('should return -2 for invalid str', function () {

--- a/test/range-parser.js
+++ b/test/range-parser.js
@@ -75,11 +75,6 @@ describe('parseRange(len, str)', function () {
     assert.strictEqual(parse(200, 'bytes=500-999,1000-1499'), -1)
   })
 
-  it('should return -1 when invalid format mixed with unsatisfiable ranges', function () {
-    assert.strictEqual(parse(200, 'bytes=500-600,900-'), -1)
-    assert.strictEqual(parse(200, 'bytes=900-,500-600'), -1)
-  })
-
   it('should parse str', function () {
     var range = parse(1000, 'bytes=0-499')
     assert.strictEqual(range.type, 'bytes')

--- a/test/range-parser.js
+++ b/test/range-parser.js
@@ -76,9 +76,9 @@ describe('parseRange(len, str)', function () {
   })
 
   it('should return -2 for mixed invalid and unsatisfiable ranges', function () {
-    assert.strictEqual(parse(200, 'bytes=abc-def,500-999'), -2)
-    assert.strictEqual(parse(200, 'bytes=500-999,xyz-uvw'), -2)
-    assert.strictEqual(parse(200, 'bytes=abc-def,500-999,xyz-uvw'), -2)
+    assert.strictEqual(parse(200, 'bytes=abc-def,500-999'), -1)
+    assert.strictEqual(parse(200, 'bytes=500-999,xyz-uvw'), -1)
+    assert.strictEqual(parse(200, 'bytes=abc-def,500-999,xyz-uvw'), -1)
   })
 
   it('should parse str', function () {

--- a/test/range-parser.js
+++ b/test/range-parser.js
@@ -41,6 +41,12 @@ describe('parseRange(len, str)', function () {
     assert.strictEqual(parse(200, 'bytes=100-15b0'), -2)
   })
 
+  it('should return -2 when all multiple ranges have invalid format', function () {
+    assert.strictEqual(parse(200, 'bytes=y-v,x-'), -2)
+    assert.strictEqual(parse(200, 'bytes=abc-def,ghi-jkl'), -2)
+    assert.strictEqual(parse(200, 'bytes=x-,y-,z-'), -2)
+  })
+
   it('should return -1 for unsatisfiable range', function () {
     assert.strictEqual(parse(200, 'bytes=500-600'), -1)
   })
@@ -53,6 +59,11 @@ describe('parseRange(len, str)', function () {
     assert.strictEqual(parse(200, 'bytes=500-20'), -1)
     assert.strictEqual(parse(200, 'bytes=500-999'), -1)
     assert.strictEqual(parse(200, 'bytes=500-999,1000-1499'), -1)
+  })
+
+  it('should return -1 when invalid format mixed with unsatisfiable ranges', function () {
+    assert.strictEqual(parse(200, 'bytes=500-600,x-'), -1)
+    assert.strictEqual(parse(200, 'bytes=x-,500-600'), -1)
   })
 
   it('should parse str', function () {
@@ -109,6 +120,28 @@ describe('parseRange(len, str)', function () {
     assert.strictEqual(range.type, 'bytes')
     assert.strictEqual(range.length, 1)
     deepEqual(range[0], { start: 999, end: 999 })
+  })
+
+  it('should ignore invalid format range when valid range exists', function () {
+    var range = parse(1000, 'bytes=100-200,x-')
+    assert.strictEqual(range.type, 'bytes')
+    assert.strictEqual(range.length, 1)
+    deepEqual(range[0], { start: 100, end: 200 })
+  })
+
+  it('should ignore invalid format ranges when some are valid', function () {
+    var range = parse(1000, 'bytes=x-,0-100,y-')
+    assert.strictEqual(range.type, 'bytes')
+    assert.strictEqual(range.length, 1)
+    deepEqual(range[0], { start: 0, end: 100 })
+  })
+
+  it('should ignore invalid format ranges at different positions', function () {
+    var range = parse(1000, 'bytes=0-50,abc-def,100-150')
+    assert.strictEqual(range.type, 'bytes')
+    assert.strictEqual(range.length, 2)
+    deepEqual(range[0], { start: 0, end: 50 })
+    deepEqual(range[1], { start: 100, end: 150 })
   })
 
   it('should parse str with multiple ranges', function () {

--- a/test/range-parser.js
+++ b/test/range-parser.js
@@ -75,6 +75,12 @@ describe('parseRange(len, str)', function () {
     assert.strictEqual(parse(200, 'bytes=500-999,1000-1499'), -1)
   })
 
+  it('should return -2 for mixed invalid and unsatisfiable ranges', function () {
+    assert.strictEqual(parse(200, 'bytes=abc-def,500-999'), -2)
+    assert.strictEqual(parse(200, 'bytes=500-999,xyz-uvw'), -2)
+    assert.strictEqual(parse(200, 'bytes=abc-def,500-999,xyz-uvw'), -2)
+  })
+
   it('should parse str', function () {
     var range = parse(1000, 'bytes=0-499')
     assert.strictEqual(range.type, 'bytes')

--- a/test/range-parser.js
+++ b/test/range-parser.js
@@ -8,6 +8,10 @@ describe('parseRange(len, str)', function () {
       /TypeError: argument str must be a string/)
   })
 
+  it('should return -2 for completely empty header', function () {
+    assert.strictEqual(parse(200, ''), -2)
+  })
+
   it('should return -2 for range missing dash', function () {
     assert.strictEqual(parse(200, 'bytes=100200'), -2)
     assert.strictEqual(parse(200, 'bytes=,100200'), -2)
@@ -31,6 +35,12 @@ describe('parseRange(len, str)', function () {
     assert.strictEqual(parse(200, 'bytes=100--200'), -2)
     assert.strictEqual(parse(200, 'bytes=-'), -2)
     assert.strictEqual(parse(200, 'bytes= - '), -2)
+  })
+
+  it('should return -2 for empty range value', function () {
+    assert.strictEqual(parse(200, 'bytes='), -2)
+    assert.strictEqual(parse(200, 'bytes=,'), -2)
+    assert.strictEqual(parse(200, 'bytes= , , '), -2)
   })
 
   it('should return -2 with multiple dashes in range', function () {
@@ -198,5 +208,12 @@ describe('parseRange(len, str)', function () {
       deepEqual(range[1], { start: 20, end: 120 })
       deepEqual(range[2], { start: 0, end: 1 })
     })
+  })
+
+  it('should ignore whitespace-only invalid ranges when valid present', function () {
+    var range = parse(1000, 'bytes= , 0-10')
+    assert.strictEqual(range.type, 'bytes')
+    assert.strictEqual(range.length, 1)
+    deepEqual(range[0], { start: 0, end: 10 })
   })
 })

--- a/test/range-parser.js
+++ b/test/range-parser.js
@@ -15,7 +15,6 @@ describe('parseRange(len, str)', function () {
   it('should return -2 for range missing dash', function () {
     assert.strictEqual(parse(200, 'bytes=100200'), -2)
     assert.strictEqual(parse(200, 'bytes=,100200'), -2)
-    assert.strictEqual(parse(200, 'bytes=100-200,100200'), -2)
   })
 
   it('should return -2 for invalid str', function () {
@@ -77,8 +76,8 @@ describe('parseRange(len, str)', function () {
   })
 
   it('should return -1 when invalid format mixed with unsatisfiable ranges', function () {
-    assert.strictEqual(parse(200, 'bytes=500-600,x-'), -1)
-    assert.strictEqual(parse(200, 'bytes=x-,500-600'), -1)
+    assert.strictEqual(parse(200, 'bytes=500-600,900-'), -1)
+    assert.strictEqual(parse(200, 'bytes=900-,500-600'), -1)
   })
 
   it('should parse str', function () {

--- a/test/range-parser.js
+++ b/test/range-parser.js
@@ -75,7 +75,7 @@ describe('parseRange(len, str)', function () {
     assert.strictEqual(parse(200, 'bytes=500-999,1000-1499'), -1)
   })
 
-  it('should return -2 for mixed invalid and unsatisfiable ranges', function () {
+  it('should return -1 for mixed invalid and unsatisfiable ranges', function () {
     assert.strictEqual(parse(200, 'bytes=abc-def,500-999'), -1)
     assert.strictEqual(parse(200, 'bytes=500-999,xyz-uvw'), -1)
     assert.strictEqual(parse(200, 'bytes=abc-def,500-999,xyz-uvw'), -1)


### PR DESCRIPTION
Before #57 and in #58, if there were multiple ranges and some of them were valid, they would still be shown.  at least this way those changes aren’t a completely breaking change.