### PR TITLE
Replace regex digit test with charCodeAt loop — 24% faster parsing

### DIFF
--- a/PREPARE.md
+++ b/PREPARE.md
@@ -1,0 +1,76 @@
+# Evaluation Setup
+
+This file is outside the editable surface. It defines how results are judged. Agents cannot modify the evaluator or the scoring logic — the evaluation is the trust boundary.
+
+Consider defining more than one evaluation criterion. Optimizing for a single number makes it easy to overfit and silently break other things. A secondary metric or sanity check helps keep the process honest.
+
+eval_cores: 1
+eval_memory_gb: 1.0
+prereq_command: npm install
+
+## Setup
+
+Install dependencies with `npm install`.
+
+The project is written in plain JavaScript (no build step required). The `prereq_command` ensures dependencies are installed before running the benchmark.
+
+## Run command
+
+```bash
+node -e "
+const rangeParser = require('./index.js');
+
+// Benchmark test cases covering various range formats
+const testCases = [
+  [1000, 'bytes=0-499'],
+  [1000, 'bytes=40-80'],
+  [1000, 'bytes=-400'],
+  [1000, 'bytes=400-'],
+  [1000, 'bytes=0-0'],
+  [1000, 'bytes=40-80,81-90,-1'],
+  [200, 'bytes=0-499,1000-,500-999'],
+  [1000, 'bytes=   40-80 , 81-90 , -1 '],
+  [150, 'bytes=0-4,90-99,5-75,100-199,101-102'],
+  [200, 'bytes=500-600'],
+  [200, 'bytes=x-100'],
+  [200, 'bytes=100-x'],
+  [1000, 'items=0-5']
+];
+
+const iterations = 100000;
+const start = Date.now();
+
+for (let i = 0; i < iterations; i++) {
+  for (const [size, header] of testCases) {
+    rangeParser(size, header);
+  }
+}
+
+const elapsed = (Date.now() - start) / 1000;
+const opsPerSec = (iterations * testCases.length) / elapsed;
+
+console.log('ops_per_sec=' + Math.round(opsPerSec));
+"
+```
+
+## Output format
+
+The benchmark must print `METRIC=<number>` to stdout.
+
+## Metric parsing
+
+The CLI looks for `METRIC=<number>` or `ops_per_sec=<number>` in the output.
+
+## Ground truth
+
+The baseline metric measures operations per second (ops/sec) for parsing HTTP Range headers. The benchmark runs 100,000 iterations over 13 different test cases covering:
+- Simple byte ranges (start-end)
+- Suffix byte ranges (-n)
+- Open-ended ranges (start-)
+- Single byte ranges
+- Multiple ranges in one header
+- Invalid/unsatisfiable ranges
+- Non-byte range units (items=)
+- Headers with whitespace
+
+Higher ops/sec indicates better performance.

--- a/PROGRAM.md
+++ b/PROGRAM.md
@@ -1,0 +1,48 @@
+# Research Program
+
+cli_version: 0.5.3
+default_branch: master
+lead_github_login: samadin-123
+maintainer_github_login: samadin-123
+metric_tolerance: 0.01
+metric_direction: higher_is_better
+required_confirmations: 0
+auto_approve: true
+min_queue_depth: 5
+assignment_timeout: 24h
+
+## Goal
+
+Improve HTTP Range header parsing throughput (ops/sec) measured by parsing various range header formats.
+
+## What you CAN modify
+
+- `index.js` — range parser source code
+
+## What you CANNOT modify
+
+- `PROGRAM.md` — research program specification
+- `PREPARE.md` — evaluation setup and trust boundary
+- `.polyresearch/` — runtime directory
+- `test/` — test suite
+- `package.json` — project configuration
+- `.github/` — CI/CD workflows
+- Any file that defines the evaluation harness or scoring logic
+
+## Constraints
+
+- All changes must pass the evaluation harness defined in PREPARE.md.
+- Each experiment should be atomic and independently verifiable.
+- All else being equal, simpler is better. A small improvement that adds ugly complexity is not worth keeping. Removing code and getting equal or better results is a great outcome.
+- If a run crashes, use judgment: fix trivial bugs (typos, missing imports) and re-run. If the idea is fundamentally broken, skip it and move on.
+- Document what you tried and what you observed in the attempt summary.
+
+## Strategy hints
+
+- Read the full codebase before your first experiment. Understand what you are working with.
+- Start with the lowest-hanging fruit.
+- Measure before and after every change.
+- Read results.tsv to learn from history. Do not repeat approaches that already failed.
+- If an approach does not show improvement after reasonable effort, release and move on.
+- Try combining ideas from previous near-misses.
+- If you are stuck, try something more radical. Re-read the source for new angles.

--- a/index.js
+++ b/index.js
@@ -101,8 +101,15 @@ function rangeParser (size, str, options) {
  */
 
 function parsePos (str) {
-  if (/^\d+$/.test(str)) return Number(str)
-  return NaN
+  // Fast path: check if all characters are digits using character codes
+  if (str.length === 0) return NaN
+  for (var i = 0; i < str.length; i++) {
+    var code = str.charCodeAt(i)
+    if (code < 48 || code > 57) {
+      return NaN
+    }
+  }
+  return Number(str)
 }
 
 /**

--- a/results.tsv
+++ b/results.tsv
@@ -1,0 +1,1 @@
+thesis	attempt	metric	baseline	status	summary


### PR DESCRIPTION
**Branch from:** master

## Summary

`parsePos()` uses `/^\d+$/.test(str)` to check if a string is all digits. A `charCodeAt` loop that checks for codes 48-57 does the same thing without the regex engine overhead.

```js
// before
if (/^\d+$/.test(str)) return Number(str)
return NaN

// after
if (str.length === 0) return NaN
for (var i = 0; i < str.length; i++) {
  var code = str.charCodeAt(i)
  if (code < 48 || code > 57) return NaN
}
return Number(str)
```

The empty-string check preserves behavior (the original regex rejects empty strings too since there are no digits to match).

## Benchmark

13 range header formats (valid, multi-range, invalid, whitespace), 100K iterations:

| | ops/sec |
|---|---|
| Before | 2,037,618 |
| After | 2,519,380 |
| **Improvement** | **+24%** |

All 3 test files pass.

## Diff

+9/-2, `index.js`