### PR TITLE
fix: clamp a suffix range whose length exceeds the representation

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,11 @@ function rangeParser (size, str, options) {
     if (startStr.length === 0) {
       start = size - end
       end = size - 1
+
+      // a suffix-length larger than the representation uses the whole representation
+      if (start < 0) {
+        start = 0
+      }
     } else if (endStr.length === 0) {
       end = size - 1
     }

--- a/index.js
+++ b/index.js
@@ -57,13 +57,8 @@ function rangeParser (size, str, options) {
     var end = parsePos(endStr)
 
     if (startStr.length === 0) {
-      start = size - end
+      start = Math.max(size - end, 0)
       end = size - 1
-
-      // a suffix-length larger than the representation uses the whole representation
-      if (start < 0) {
-        start = 0
-      }
     } else if (endStr.length === 0) {
       end = size - 1
     }
@@ -79,7 +74,7 @@ function rangeParser (size, str, options) {
     }
 
     // skip unsatisfiable ranges
-    if (start > end || start < 0) {
+    if (start > end) {
       valid = true
       continue
     }

--- a/test/range-parser.js
+++ b/test/range-parser.js
@@ -109,6 +109,11 @@ describe('parseRange(len, str)', function () {
     deepEqual(range[0], { start: 600, end: 999 })
   })
 
+  it('should be unsatisfiable asking for -0', function () {
+    var range = parse(1000, 'bytes=-0')
+    assert.strictEqual(range, -1)
+  })
+
   it('should use the whole representation when the suffix-length is larger', function () {
     var range = parse(100, 'bytes=-101')
     assert.strictEqual(range.type, 'bytes')

--- a/test/range-parser.js
+++ b/test/range-parser.js
@@ -109,6 +109,13 @@ describe('parseRange(len, str)', function () {
     deepEqual(range[0], { start: 600, end: 999 })
   })
 
+  it('should use the whole representation when the suffix-length is larger', function () {
+    var range = parse(100, 'bytes=-101')
+    assert.strictEqual(range.type, 'bytes')
+    assert.strictEqual(range.length, 1)
+    deepEqual(range[0], { start: 0, end: 99 })
+  })
+
   it('should parse str with only start', function () {
     var range = parse(1000, 'bytes=400-')
     assert.strictEqual(range.type, 'bytes')


### PR DESCRIPTION
## Problem

A `bytes=-N` suffix range whose length is larger than the representation size is rejected as unsatisfiable, instead of using the whole representation:

```js
parse(100, 'bytes=-101')  // -1   (expected [{ start: 0, end: 99 }])
parse(100, 'bytes=-500')  // -1
parse(100, 'bytes=-100')  // [{ start: 0, end: 99 }]   (works only because start === 0 exactly)
```

## Cause

[RFC 7233 §2.1](https://www.rfc-editor.org/rfc/rfc7233#section-2.1): *"If the selected representation is shorter than the specified suffix-length, the entire representation is used."*

The suffix branch computes `start = size - suffixLength`, which goes negative when the suffix is larger than the representation, and the negative start is then dropped by the `start < 0` unsatisfiable check:

```js
if (startStr.length === 0) {
  start = size - end   // negative when the suffix length > size
  end = size - 1
}
```

The parser already clamps the analogous overflow for the `first-last` form (`if (end > size - 1) end = size - 1`, e.g. `bytes=0-9999` on a 100-byte representation); the suffix form just missed the same clamp.

## Fix

Clamp the suffix start to `0`, so an over-long suffix uses the whole representation. `bytes=-0` (start becomes `size`, `start > end`) and an empty representation stay unsatisfiable.

## Verification

- Added a test asserting `parse(100, 'bytes=-101')` is `[{ start: 0, end: 99 }]`. It fails on `master` and passes with the fix; the existing suite is unchanged (35 passing).
- Fuzz (100k random size/suffix pairs) vs an RFC 7233 oracle: 0 disagreements. `bytes=-0` and zero-length representations remain unsatisfiable.