### PR TITLE
fix: keep original order when a combined range is fully absorbed

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,9 +120,11 @@ function combineRanges (ranges) {
     if (range.start > current.end + 1) {
       // next range
       ordered[++j] = range
-    } else if (range.end > current.end) {
-      // extend range
-      current.end = range.end
+    } else {
+      // overlapping or adjacent range
+      if (range.end > current.end) {
+        current.end = range.end
+      }
       current.index = Math.min(current.index, range.index)
     }
   }

--- a/test/range-parser.js
+++ b/test/range-parser.js
@@ -220,6 +220,16 @@ describe('parseRange(len, str)', function () {
       deepEqual(range[1], { start: 20, end: 120 })
       deepEqual(range[2], { start: 0, end: 1 })
     })
+
+    it('should retain original order when an earlier range is absorbed', function () {
+      var range = parse(1000, 'bytes=50-60,200-300,0-100', { combine: true })
+      assert.strictEqual(range.type, 'bytes')
+      assert.strictEqual(range.length, 2)
+      assert.strictEqual(range[0].start, 0)
+      assert.strictEqual(range[0].end, 100)
+      assert.strictEqual(range[1].start, 200)
+      assert.strictEqual(range[1].end, 300)
+    })
   })
 
   it('should ignore whitespace-only invalid ranges when valid present', function () {


### PR DESCRIPTION
With `combine: true`, ranges are returned "as if they were specified that way in the header", preserving original order (see the existing `should retain original order` test). `combineRanges` tracks that order via each range's original `index` and restores it at the end with `sortByRangeIndex`.

When ranges are sorted by start position, a range that is fully contained inside the current one (`range.end <= current.end`) is absorbed. The absorb path never ran, so `current.index` was only updated in the `extend` branch. If the absorbed range appeared earlier in the header, its lower index was lost and the combined group sorted into the wrong output position.

Repro:

```js
parseRange(1000, 'bytes=50-60,200-300,0-100', { combine: true })
// actual:   [ { start: 200, end: 300 }, { start: 0, end: 100 } ]
// expected: [ { start: 0, end: 100 }, { start: 200, end: 300 } ]
```

`0-100` absorbs `50-60`, which is the first spec in the header, so that group's earliest appearance is position 0 and it should come before `200-300` at position 1.

Fix: take `Math.min(current.index, range.index)` whenever a range is merged (overlapping or adjacent), not only when it extends the end. Adds a regression test. All existing tests still pass.
